### PR TITLE
Remove red dots from carousel example

### DIFF
--- a/src/app/components/carousel-example.tsx
+++ b/src/app/components/carousel-example.tsx
@@ -64,17 +64,6 @@ export default function CarouselExample() {
         <CarouselPrevious className="carousel-example-previous" />
         <CarouselNext className="carousel-example-next" />
       </Carousel>
-      
-      {/* Indicadores de pontos personalizados */}
-      <div className="carousel-example-dots">
-        {mediaItems.map((_, index) => (
-          <div
-            key={index}
-            className="carousel-example-dot"
-            aria-label={`Ir para projeto ${index + 1}`}
-          />
-        ))}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
Remove carousel pagination dots as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-550877a2-f567-4b08-9434-9128bfb47458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-550877a2-f567-4b08-9434-9128bfb47458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

