### PR TITLE
Fix hero and components position

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,8 +30,8 @@ export default function RootLayout({
         <div style={{position: 'relative' }}>
           <DarkVeil />
           <GradientBG />
+          {children}
         </div>
-        {children}
       </body>
     </html>
   );


### PR DESCRIPTION
Move `children` inside the background container to ensure components appear on top of backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf5db94c-ce9d-4660-a13e-e406de455925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf5db94c-ce9d-4660-a13e-e406de455925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

