### PR TITLE
Adicionar transparência 0.1 no MagicBento

### DIFF
--- a/src/blocks/Components/MagicBento/MagicBento.tsx
+++ b/src/blocks/Components/MagicBento/MagicBento.tsx
@@ -38,37 +38,37 @@ const MOBILE_BREAKPOINT = 768;
 
 const cardData: BentoCardProps[] = [
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Analytics",
     description: "Track user behavior",
     label: "Insights",
   },
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Dashboard",
     description: "Centralized data view",
     label: "Overview",
   },
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Collaboration",
     description: "Work together seamlessly",
     label: "Teamwork",
   },
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Automation",
     description: "Streamline workflows",
     label: "Efficiency",
   },
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Integration",
     description: "Connect favorite tools",
     label: "Connectivity",
   },
   {
-    color: "#060010",
+    color: "rgba(6, 0, 16, 0.1)",
     title: "Security",
     description: "Enterprise-grade protection",
     label: "Protection",


### PR DESCRIPTION
Add 0.1 transparency to the colors in `MagicBento.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-13035880-47c0-4acf-98b3-7f242f8b2f53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13035880-47c0-4acf-98b3-7f242f8b2f53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

